### PR TITLE
Lecan Tract

### DIFF
--- a/Lec/clann_morna.trig
+++ b/Lec/clann_morna.trig
@@ -820,7 +820,8 @@ _:missing-d23e02b6
 <#Fidaig>
         a foaf:Person;
         irishRel:genName "Fidaig";
-        rel:childOf <#RainRogloin>.
+        rel:childOf <#RainRogloin>;
+        owl:sameAs <#Figda>.
 
 <#RainRogloin>
         a foaf:Person;

--- a/Lec/rigraid_connacht_tar_eis_aillela_agus_meadba.trig
+++ b/Lec/rigraid_connacht_tar_eis_aillela_agus_meadba.trig
@@ -1,0 +1,23 @@
+@base <http://example.com/Lec/rigraid_connacht_tar_eis_aillela_agus_meadba.trig> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix rel: <http://purl.org/vocab/relationship/>.
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix irishRel: <http://example.com/earlyirishRelationship.ttl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix irishTitles: <http://example.com/earlyIrishTitles.ttl#> .
+
+<http://example.com/Lec> {
+  <> a dctype:Dataset ;
+        dcterms:title "Rigraid Connacht tar eis Aillela agus Meadba"@sga ;
+        dcterms:isFormatOf <https://www.isos.dias.ie/libraries/RIA/RIA_MS_23_P_2/small_jpgs/353.jpg>, <https://www.isos.dias.ie/libraries/RIA/RIA_MS_23_P_2/small_jpgs/354.jpg>, <https://www.isos.dias.ie/libraries/RIA/RIA_MS_23_P_2/large_jpgs/353.jpg>, <https://www.isos.dias.ie/libraries/RIA/RIA_MS_23_P_2/large_jpgs/354.jpg> ;
+        dcterms:format "application/trig" ;
+        prov:asDerivedFrom <https://www.isos.dias.ie/libraries/RIA/RIA_MS_23_P_2/small_jpgs/353.jpg>, <https://www.isos.dias.ie/libraries/RIA/RIA_MS_23_P_2/large_jpgs/354.jpg>, <https://www.isos.dias.ie/libraries/RIA/RIA_MS_23_P_2/small_jpgs/353.jpg>, <https://www.isos.dias.ie/libraries/RIA/RIA_MS_23_P_2/large_jpgs/354.jpg> .
+
+
+
+
+}

--- a/Lec/rigraid_connacht_tar_eis_aillela_agus_meadba.trig
+++ b/Lec/rigraid_connacht_tar_eis_aillela_agus_meadba.trig
@@ -17,7 +17,230 @@
         dcterms:format "application/trig" ;
         prov:asDerivedFrom <https://www.isos.dias.ie/libraries/RIA/RIA_MS_23_P_2/small_jpgs/353.jpg>, <https://www.isos.dias.ie/libraries/RIA/RIA_MS_23_P_2/large_jpgs/354.jpg>, <https://www.isos.dias.ie/libraries/RIA/RIA_MS_23_P_2/small_jpgs/353.jpg>, <https://www.isos.dias.ie/libraries/RIA/RIA_MS_23_P_2/large_jpgs/354.jpg> .
 
+<#ConallChruachna>
+    a foaf:Person;
+    irishRel:nomName "Conall Chruachna";
+    rel:childOf <#AengusaFeirt>;
+    owl:sameAs <http://example.com/Lec/clann_morna.trig#ConaillCruachna>.
 
+<#AengusaFeirt>
+    a foaf:Person;
+    irishRel:nomName "Aengus Fert";
+    irishRel:genName "Aengusa Feirt";
+    rel:childOf <#AengusaFind>;
+    owl:sameAs <http://example.com/Lec/clann_morna.trig#AengusaFert>.
 
+<#AengusaFind>
+    a foaf:Person;
+    irishRel:nomName "Aengus Find";
+    irishRel:genName "Aengusa Find";
+    rel:childOf <#Fhidic>;
+    owl:sameAs <http://example.com/Lec/clann_morna.trig#AengusaFind>.
+
+<#Fhidic>
+    a foaf:Person;
+    irishRel:nomName "Feidic";
+    irishRel:genName "Fhidic";
+    rel:childOf <#Feicc>;
+    owl:sameAs <http://example.com/Lec/clann_morna.trig#Fhidaig>.
+
+<#Feicc>
+    a foaf:Person;
+    irishRel:genName "Feicc";
+    irishRel:nomName "Fiacc";
+    rel:childOf <#AedaFind>;
+    owl:sameAs <http://example.com/Lec/clann_morna.trig#Feic>.
+
+<#AedaFind>
+    a foaf:Person;
+    irishRel:genName "Aeda Find";
+    irishRel:nomName "Aed Find";
+    rel:childOf <#DairiDomnanaich>;
+    owl:sameAs <http://example.com/Lec/clann_morna.trig#AedaFind>.
+
+<#DairiDomnanaich>
+    a foaf:Person;
+    irishRel:genName "Dairi Domnanaich";
+    irishRel:nomName "Daire Domanach";
+    rel:childOf <#IlairTheadma>;
+    owl:sameAs <http://example.com/Lec/clann_morna.trig#DairiDomnandaich>.
+
+<#IlairTheadma>
+    a foaf:Person;
+    irishRel:genName "Ilair Theadma";
+    irishRel:nomName "Ilar Teadma";
+    rel:childOf <#Figda>;
+    owl:sameAs <http://example.com/Lec/clann_morna.trig#Ilair>.
+
+<#Figda>
+    a foaf:Person;
+    irishRel:genName "Figda";
+    irishRel:nomName "Fidaig";
+    rel:childOf <#ReinRogloin>;
+    owl:sameAs <http://example.com/Lec/clann_morna.trig#Figda>.
+
+<#ReinRogloin>
+    a foaf:Person;
+    irishRel:genName "Rein Rogloin";
+    rel:childOf <#TuamaTened>;
+    owl:sameAs <http://example.com/Lec/clann_morna.trig#RainRogloin>.
+
+<#TuamaTened>
+    a foaf:Person;
+    irishRel:genName "Tuama Tened";
+    rel:childOf <#FhirDaBenn>;
+    owl:sameAs <http://example.com/Lec/clann_morna.trig#TuamaTened>.
+
+<#FhirDaBenn>
+    a foaf:Person;
+    irishRel:genName "Fhir Da Benn";
+    irishRel:nomName "Fer Da Benn";
+    rdfs:comment ".i. bend chuic oigli agus benn boirnne uair ba ri seom eturru sin";
+    rel:childOf <#DoilbRindGlais>;
+    owl:sameAs <http://example.com/Lec/clann_morna.trig#FirDaBeand>.
+
+<#DoilbRindGlais>
+    a foaf:Person;
+    irishRel:genName "Doilb Rind Glais";
+    rel:childOf <#FhaelchonFhuilig>.
+
+<#FhaelchonFhuilig>
+    a foaf:Person;
+    irishRel:genName "Fhaelchon Fhuilig";
+    irishRel:nomName "Faelchu Fuilech";
+    rel:childOf <#FhirDaThonn>.
+
+<#FhirDaThonn>
+    a foaf:Person;
+    irishRel:genName "Fhir Da Thonn";
+    irishRel:nomName "Fer Da Thonn";
+    rdfs:comment ".i. tond indsi caerach i corco baiscind agus tonn indsi gluair i tuaid";
+    rel:childOf <#FhirDumaMoir>.
+
+<#FhirDumaMoir>
+    a foaf:Person;
+    irishRel:genName "Fhir Duma Moir";
+    irishRel:nomName "Fer Duma Moir";
+    rel:childOf <#FirDaMag>.
+
+<#FirDaMag>
+    a foaf:Person;
+    irishRel:genName "Fir Da Mag";
+    irishRel:nomName "Fer Da Mag";
+    rdfs:comment ".i.senmag sainb agus senmag agair mic umoir uair ba ri seom eaturru sin";
+    rel:childOf <#EnnaUarchosaig>.
+
+<#EnnaUarchosaig>
+    a foaf:Person;
+    irishRel:genName "Enna Uarchosaig";
+    rdfs:comment "air nir gabus tair asa ina cosaib riam";
+    rel:childOf <#Genaind>.
+
+<#Genaind>
+    a foaf:Person;
+    irishRel:genName "Genaind";
+    irishRel:nomName "Genand";
+    rel:childOf <#Deala>.
+
+<#Deala>
+    a foaf:Person;
+    irishRel:genName "Deala";
+    rel:childOf <#Loith>;
+    owl:sameAs <http://example.com/Rawl_B512/ferchuitred_medba.trig#Dela>.
+
+<#Loith>
+    a foaf:Person;
+    irishRel:genName "Loith";
+    irishRel:nomName "Loth";
+    rel:childOf <#Foirtheacht>;
+    owl:sameAs <http://example.com/Rawl_B512/ferchuitred_medba.trig#Loich>.
+
+<#Thribuaith>
+    a foaf:Person;
+    irishRel:genName "Thribuaith";
+    rel:childOf <#Fhorthoirb>.
+
+<#Fhorthoirb>
+    a foaf:Person;
+    irishRel:genName "Fhorthoirb";
+    rel:childOf <#Osmein>.
+
+<#Osmein>
+    a foaf:Person;
+    irishRel:genName "Osmein";
+    rel:childOf <#Foirthech>.
+
+<#Foirthech>
+    a foaf:Person;
+    irishRel:genName "Foirthech";
+    rel:childOf <#Semeoin>.
+
+<#Semeoin>
+    a foaf:Person;
+    irishRel:genName "Semeoin";
+    rel:childOf <#Sdairn>.
+
+<#Sdairn>
+    a foaf:Person;
+    irishRel:genName "Sdairn";
+    rel:childOf <#Nemid>.
+
+<#Nemid>
+    a foaf:Person;
+    irishRel:genName "Nemid";
+    rel:childOf <#Adnomaini>.
+
+<#Adnomaini>
+    a foaf:Person;
+    irishRel:genName "Adnomaini";
+    rel:childOf <#Paim>.
+
+<#Paim>
+    a foaf:Person;
+    irishRel:genName "Paim";
+    rel:childOf <#Thait>.
+
+<#Thait>
+    a foaf:Person;
+    irishRel:genName "Thait";
+    rel:childOf <#Sera>.
+
+<#Sera>
+    a foaf:Person;
+    irishRel:genName "Sera";
+    rel:childOf <#Sru>.
+
+<#Sru>
+    a foaf:Person;
+    irishRel:genName "Sru";
+    rel:childOf <#Easru>;
+    owl:sameAs <http://example.com/LL/section_135.trig#Sru>.
+
+<#Easru>
+    a foaf:Person;
+    irishRel:genName "Easru";
+    rel:childOf <#GaedilGlais>;
+    owl:sameAs <http://example.com/LL/section_135.trig#Esrú>.
+
+<#GaedilGlais>
+    a foaf:Person;
+    irishRel:genName "Gaedil Glais";
+    irishRel:ancestorOfGroup <#Gaedil>;
+    owl:sameAs <http://example.com/LL/section_135.trig#GaidilGlais>.
+
+<#Gaedil>
+    a irishRel:PopulationGroup;
+    irishRel:populationGroupName "Gaedil";
+
+<#Nemed>
+    a foaf:Person;
+    irishRel:nomName "Nemed";
+    rel:descendantOf <#Easru>;
+    owl:sameAs <#Nemid>.
+
+<#Pairthalon>
+    a foaf:Person;
+    irishRel:nomName "Pairthalon";
+    rel:descendantOf <#Easru>.
 
 }

--- a/Lec/rigraid_connacht_tar_eis_aillela_agus_meadba.trig
+++ b/Lec/rigraid_connacht_tar_eis_aillela_agus_meadba.trig
@@ -230,7 +230,7 @@
 
 <#Gaedil>
     a irishRel:PopulationGroup;
-    irishRel:populationGroupName "Gaedil";
+    irishRel:populationGroupName "Gaedil".
 
 <#Nemed>
     a foaf:Person;


### PR DESCRIPTION
There is a pedigree in the Book of Lecan, immediately preceding the Clann Morna tract, that nicely contextualises both that text and some characters in _Ferchuitred Medba_. It's been added here. Preceding this in the MS is a history of the royal succession of Connacht, which could be usefully added too at some point in the future.